### PR TITLE
Update Lib_MapFunctionalDiversity.R

### DIFF
--- a/R/Lib_MapFunctionalDiversity.R
+++ b/R/Lib_MapFunctionalDiversity.R
@@ -49,7 +49,7 @@ map_functional_div <- function(Original_Image_File,Functional_File = FALSE,
   # check if selected features match with image dimensions
   HDRname <- get_HDR_name(Functional_File)
   HDR <- read_ENVI_header(HDRname)
-  if (Selected_Features==FALSE){
+  if (Selected_Features[1]==[]){
     Selected_Features = seq(1,HDR$bands)
   } else {
     if (max(Selected_Features)>HDR$bands){


### PR DESCRIPTION
When it carries out 'if' conditional sentences, it would have warnings"if (Selected_Features == FALSE) { :
The length of the condition is greater than one, so you can only use its first element"