### PR TITLE
Dev

### DIFF
--- a/.github/workflows/tic.yml
+++ b/.github/workflows/tic.yml
@@ -114,7 +114,7 @@ jobs:
         if: matrix.config.os == 'macOS-latest' && matrix.config.r == 'devel'
         run: |
           echo -e 'options(Ncpus = 4, pkgType = "source", repos = structure(c(CRAN = "https://cloud.r-project.org/")))' > $HOME/.Rprofile
-          Rscript -e "remotes::install_github('ropensci/tic')" -e "print(tic::dsl_load())" -e "tic::prepare_all_stages()" -e "tic::before_install()" -e "tic::install()"
+          Rscript -e "remotes::install_github('ropensci/tic')" -e "print(tic::dsl_load())" -e "tic::prepare_all_stages()" -e "tic::before_install()" -e "options(pkgType='binary'); tic::install()"
 
       - name: "[Stage] Script"
         run: Rscript -e 'tic::script()'

--- a/.github/workflows/tic.yml
+++ b/.github/workflows/tic.yml
@@ -100,7 +100,7 @@ jobs:
 
       - name: "[Stage] [macOS] Install system libs for terra"
         if: runner.os == 'macOS' && matrix.config.pkgdown != ''
-        run: brew install pkg-config gdal
+        run: |brew install pkg-config gdal proj
 
       - name: "[Stage] Install"
         if: matrix.config.os != 'macOS-latest' || matrix.config.r != 'devel'

--- a/.github/workflows/tic.yml
+++ b/.github/workflows/tic.yml
@@ -99,7 +99,7 @@ jobs:
         run: sudo apt install libharfbuzz-dev libfribidi-dev
 
       - name: "[Stage] [macOS] Install system libs for terra"
-        if: runner.os == 'macOS' && matrix.config.pkgdown != ''
+        if: runner.os == 'macOS'
         run: |
             # from https://github.com/r-spatial/sf/blob/main/.github/workflows/tic.yml
             # maybe not necessary anymore as package terra is installed from binary

--- a/.github/workflows/tic.yml
+++ b/.github/workflows/tic.yml
@@ -100,9 +100,9 @@ jobs:
         if: runner.os == 'Linux' && matrix.config.pkgdown != ''
         run: sudo apt install libharfbuzz-dev libfribidi-dev
 
-#      - name: "[Stage] [macOS] Install system libs for terra"
-#        if: runner.os == 'macOS' && matrix.config.pkgdown != ''
-#        run: brew install pkg-config gdal proj
+      - name: "[Stage] [macOS] Install system libs for terra"
+        if: runner.os == 'macOS' && matrix.config.pkgdown != ''
+        run: Rscript -e "install.packages('terra')"
 
       - name: "[Stage] Install"
         if: matrix.config.os != 'macOS-latest' || matrix.config.r != 'devel'

--- a/.github/workflows/tic.yml
+++ b/.github/workflows/tic.yml
@@ -101,8 +101,11 @@ jobs:
       - name: "[Stage] [macOS] Install system libs for terra"
         if: runner.os == 'macOS' && matrix.config.pkgdown != ''
         run: |
-            rm '/usr/local/bin/gfortran'
-            brew install pkg-config gdal proj geos
+            # from https://github.com/r-spatial/sf/blob/main/.github/workflows/tic.yml
+            # maybe not necessary anymore as package terra is installed from binary
+            # rm '/usr/local/bin/gfortran'
+            # brew install pkg-config gdal proj geos
+            # preinstall package terra binary as compilation from source fails for macOS-latest
             Rscript -e "install.packages('terra', type='binary')"
 
       - name: "[Stage] Install"
@@ -114,7 +117,7 @@ jobs:
         if: matrix.config.os == 'macOS-latest' && matrix.config.r == 'devel'
         run: |
           echo -e 'options(Ncpus = 4, pkgType = "source", repos = structure(c(CRAN = "https://cloud.r-project.org/")))' > $HOME/.Rprofile
-          Rscript -e "remotes::install_github('ropensci/tic')" -e "print(tic::dsl_load())" -e "tic::prepare_all_stages()" -e "tic::before_install()" -e "options(pkgType='binary'); tic::install()"
+          Rscript -e "remotes::install_github('ropensci/tic')" -e "print(tic::dsl_load())" -e "tic::prepare_all_stages()" -e "tic::before_install()" -e "tic::install()"
 
       - name: "[Stage] Script"
         run: Rscript -e 'tic::script()'

--- a/.github/workflows/tic.yml
+++ b/.github/workflows/tic.yml
@@ -43,7 +43,7 @@ jobs:
       # use GITHUB_TOKEN from GitHub to workaround rate limits in {remotes}
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       # avoid problems with terra dependencies when building terra from source
-      R_REMOTES_UPGRADE: false
+      R_REMOTES_UPGRADE: never
 
     steps:
       - uses: actions/checkout@v2.3.4

--- a/.github/workflows/tic.yml
+++ b/.github/workflows/tic.yml
@@ -42,8 +42,6 @@ jobs:
       SDKROOT: /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk
       # use GITHUB_TOKEN from GitHub to workaround rate limits in {remotes}
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-      # avoid problems with terra dependencies when building terra from source
-      R_REMOTES_UPGRADE: never
 
     steps:
       - uses: actions/checkout@v2.3.4
@@ -102,7 +100,10 @@ jobs:
 
       - name: "[Stage] [macOS] Install system libs for terra"
         if: runner.os == 'macOS' && matrix.config.pkgdown != ''
-        run: Rscript -e "install.packages('terra')"
+        run: |
+            rm '/usr/local/bin/gfortran'
+            brew install pkg-config gdal proj geos
+            Rscript -e "install.packages('terra', type='binary')"
 
       - name: "[Stage] Install"
         if: matrix.config.os != 'macOS-latest' || matrix.config.r != 'devel'

--- a/.github/workflows/tic.yml
+++ b/.github/workflows/tic.yml
@@ -42,6 +42,8 @@ jobs:
       SDKROOT: /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk
       # use GITHUB_TOKEN from GitHub to workaround rate limits in {remotes}
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      # avoid problems with terra dependencies when building terra from source
+      R_REMOTES_UPGRADE: false
 
     steps:
       - uses: actions/checkout@v2.3.4
@@ -98,9 +100,9 @@ jobs:
         if: runner.os == 'Linux' && matrix.config.pkgdown != ''
         run: sudo apt install libharfbuzz-dev libfribidi-dev
 
-      - name: "[Stage] [macOS] Install system libs for terra"
-        if: runner.os == 'macOS' && matrix.config.pkgdown != ''
-        run: brew install pkg-config gdal proj
+#      - name: "[Stage] [macOS] Install system libs for terra"
+#        if: runner.os == 'macOS' && matrix.config.pkgdown != ''
+#        run: brew install pkg-config gdal proj
 
       - name: "[Stage] Install"
         if: matrix.config.os != 'macOS-latest' || matrix.config.r != 'devel'

--- a/.github/workflows/tic.yml
+++ b/.github/workflows/tic.yml
@@ -100,7 +100,7 @@ jobs:
 
       - name: "[Stage] [macOS] Install system libs for terra"
         if: runner.os == 'macOS' && matrix.config.pkgdown != ''
-        run: |brew install pkg-config gdal proj
+        run: brew install pkg-config gdal proj
 
       - name: "[Stage] Install"
         if: matrix.config.os != 'macOS-latest' || matrix.config.r != 'devel'

--- a/.github/workflows/tic.yml
+++ b/.github/workflows/tic.yml
@@ -98,6 +98,10 @@ jobs:
         if: runner.os == 'Linux' && matrix.config.pkgdown != ''
         run: sudo apt install libharfbuzz-dev libfribidi-dev
 
+      - name: "[Stage] [macOS] Install system libs for terra"
+        if: runner.os == 'macOS' && matrix.config.pkgdown != ''
+        run: brew install pkg-config gdal
+
       - name: "[Stage] Install"
         if: matrix.config.os != 'macOS-latest' || matrix.config.r != 'devel'
         run: Rscript -e "remotes::install_github('ropensci/tic')" -e "print(tic::dsl_load())" -e "tic::prepare_all_stages()" -e "tic::before_install()" -e "tic::install()"

--- a/tic.R
+++ b/tic.R
@@ -1,5 +1,5 @@
 # installs dependencies, runs R CMD check, runs covr::codecov()
-do_package_checks()
+do_package_checks(error_on='error')
 
 if (ci_on_ghactions() && ci_has_env("BUILD_PKGDOWN")) {
   # creates pkgdown site and pushes to gh-pages branch


### PR DESCRIPTION
fix CI for Win and macOS:
- error in Win CI comes from warnings (collisions between methods of terra and raster). Error is avoided adding error_on='error' in tic.R
- error in macOS comes from package terra compilation at install_deps. Error is avoided preinstalling terra before stage Install 