### PR TITLE
Update tic.yml

### DIFF
--- a/.github/workflows/tic.yml
+++ b/.github/workflows/tic.yml
@@ -141,7 +141,7 @@ jobs:
 
       - name: "[Stage] Upload R CMD check artifacts"
         if: failure()
-        uses: actions/upload-artifact@v2.2.1
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ runner.os }}-r${{ matrix.config.r }}-results
           path: check


### PR DESCRIPTION
CI failure states:

> This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v2.2.1`.

This PR aims at fixing that failure.